### PR TITLE
Fix for cases where 'repeats' is missing from message_dict

### DIFF
--- a/pilight/pilight.py
+++ b/pilight/pilight.py
@@ -135,7 +135,7 @@ class Client(threading.Thread):
                         # Filter: Only use receiver messages
                         if 'receiver' in message_dict['origin']:
                             if self.veto_repeats:
-                                if message_dict['repeats'] == 1:
+                                if message_dict.get('repeats', 1) == 1:
                                     self.callback(message_dict)
                             else:
                                 self.callback(message_dict)


### PR DESCRIPTION
I was trying to have home assistant talk to my DHT22 connected via pilight.
However, that failed when trying to read "repeats" from the message_dict.

For some reason it seems that this key is simply not present - not sure why.

Setting veto_repeats to False in the c'tor also seems to work around this problem, but I thought this may be the better solution as other devices may have the key present.