### PR TITLE
WIP: Add protocol schema handling

### DIFF
--- a/pilight/pilight.py
+++ b/pilight/pilight.py
@@ -8,6 +8,8 @@ import socket
 import json
 import logging
 
+from pilight import protocol_schema
+
 
 class Client(threading.Thread):
 
@@ -103,6 +105,11 @@ class Client(threading.Thread):
                 answer_1, answer_2)
 
         self.callback = None
+        self.protocol_registry = self._load_protocol_schema()
+
+    def _load_protocol_schema(self):
+        # Use static protocol schema dump until we have PR #322 merged.
+        return protocol_schema.ProtocolRegistry()
 
     def set_callback(self, function):
         """Function to be called when data is received."""

--- a/pilight/protocol_list.json
+++ b/pilight/protocol_list.json
@@ -7,19 +7,19 @@
       "name": "ping",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "ip"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "disconnected"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "connected"
@@ -33,25 +33,25 @@
       "name": "arping",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "ip"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "mac"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "disconnected"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "connected"
@@ -65,13 +65,13 @@
       "name": "generic_webcam",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "url"
@@ -85,25 +85,25 @@
       "name": "generic_weather",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "battery"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "humidity"
@@ -117,19 +117,19 @@
       "name": "generic_switch",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -143,19 +143,19 @@
       "name": "generic_screen",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "down"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "up"
@@ -169,20 +169,20 @@
       "name": "generic_label",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "color"
         },
         {
-          "data_type": [
+          "vartype": [
             "string",
             "number"
           ],
           "name": "label"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
@@ -196,25 +196,25 @@
       "name": "generic_dimmer",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "dimlevel"
@@ -228,13 +228,13 @@
       "name": "raw",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "repeats"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "code"
@@ -248,19 +248,19 @@
       "name": "pilight_firmware",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "hpf"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "lpf"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "version"
@@ -274,19 +274,19 @@
       "name": "pilight_firmware",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "hpf"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "lpf"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "version"
@@ -300,19 +300,19 @@
       "name": "relay",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "gpio"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -326,13 +326,13 @@
       "name": "lm76",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
@@ -346,13 +346,13 @@
       "name": "lm75",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
@@ -366,19 +366,19 @@
       "name": "gpio_switch",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "gpio"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -392,13 +392,13 @@
       "name": "ds18s20",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
@@ -412,13 +412,13 @@
       "name": "ds18b20",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
@@ -433,19 +433,19 @@
       "name": "dht22",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "gpio"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "humidity"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
@@ -459,19 +459,19 @@
       "name": "dht11",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "gpio"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "humidity"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
@@ -486,25 +486,25 @@
       "name": "bmp180",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "pressure"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "oversampling"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "id"
@@ -519,25 +519,25 @@
       "name": "xbmc",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "port"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "server"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "media"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "action"
@@ -551,55 +551,55 @@
       "name": "wunderground",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "update"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "sun"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "sunset"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "sunrise"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "country"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "location"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "api"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "humidity"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
@@ -613,31 +613,31 @@
       "name": "sunriseset",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "sun"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "sunset"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "sunrise"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "latitude"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "longitude"
@@ -651,55 +651,55 @@
       "name": "program",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "stopped"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "pending"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "running"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "arguments"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "pid"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "program"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "stop-command"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "start-command"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "name"
@@ -713,49 +713,49 @@
       "name": "openweathermap",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "update"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "sun"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "sunset"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "sunrise"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "country"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "location"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "humidity"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
@@ -769,25 +769,25 @@
       "name": "lirc",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "remote"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "button"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "repeat"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "code"
@@ -801,61 +801,61 @@
       "name": "datetime",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "dst"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "second"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "minute"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "hour"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "weekday"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "day"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "month"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "year"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "latitude"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "longitude"
@@ -869,13 +869,13 @@
       "name": "cpu_temp",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
@@ -889,19 +889,19 @@
       "name": "x10",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -915,19 +915,19 @@
       "name": "tfa30",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "humidity"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
@@ -945,31 +945,31 @@
       "name": "tfa",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "battery"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "humidity"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "channel"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
@@ -983,25 +983,25 @@
       "name": "teknihall",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "battery"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "humidity"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
@@ -1015,25 +1015,25 @@
       "name": "techlico_switch",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -1047,25 +1047,25 @@
       "name": "tcm",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "battery"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "humidity"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
@@ -1079,25 +1079,25 @@
       "name": "silvercrest",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unitcode"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "systemcode"
@@ -1111,19 +1111,19 @@
       "name": "selectremote",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
@@ -1137,13 +1137,13 @@
       "name": "secudo_smoke_sensor",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "alarm"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
@@ -1157,25 +1157,25 @@
       "name": "sc2262",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "closed"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "opened"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unitcode"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "systemcode"
@@ -1190,25 +1190,25 @@
       "name": "rsl366",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "programcode"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "systemcode"
@@ -1222,25 +1222,25 @@
       "name": "rev3_switch",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -1254,25 +1254,25 @@
       "name": "rev2_switch",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -1286,25 +1286,25 @@
       "name": "rev1_switch",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -1319,31 +1319,31 @@
       "name": "rc101",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "all"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
@@ -1357,37 +1357,37 @@
       "name": "quigg_screen",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "learn"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "all"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "down"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "up"
@@ -1401,25 +1401,25 @@
       "name": "quigg_gt9000",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -1433,37 +1433,37 @@
       "name": "quigg_gt7000",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "learn"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "all"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -1477,43 +1477,43 @@
       "name": "quigg_gt1000",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "num"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "super"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "all"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -1527,25 +1527,25 @@
       "name": "pollin",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unitcode"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "systemcode"
@@ -1559,25 +1559,25 @@
       "name": "ninjablocks_weather",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "humidity"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
@@ -1591,25 +1591,25 @@
       "name": "mumbi",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unitcode"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "systemcode"
@@ -1623,25 +1623,25 @@
       "name": "logilink_switch",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unitcode"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "systemcode"
@@ -1655,25 +1655,25 @@
       "name": "impuls",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "programcode"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "systemcode"
@@ -1687,25 +1687,25 @@
       "name": "heitech",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unitcode"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "systemcode"
@@ -1719,19 +1719,19 @@
       "name": "ev1527",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "closed"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "opened"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unitcode"
@@ -1745,37 +1745,37 @@
       "name": "eurodomest_switch",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "learn"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "all"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -1791,25 +1791,25 @@
       "name": "elro_800_switch",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unitcode"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "systemcode"
@@ -1823,25 +1823,25 @@
       "name": "elro_800_contact",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "closed"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "opened"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unitcode"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "systemcode"
@@ -1855,25 +1855,25 @@
       "name": "elro_400_switch",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unitcode"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "systemcode"
@@ -1887,31 +1887,31 @@
       "name": "elro_300_switch",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "all"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unitcode"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "systemcode"
@@ -1925,19 +1925,19 @@
       "name": "ehome",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
@@ -1951,31 +1951,31 @@
       "name": "daycom",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "systemcode"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -1989,37 +1989,37 @@
       "name": "conrad_rsl_switch",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "learn"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "all"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
@@ -2033,19 +2033,19 @@
       "name": "conrad_rsl_contact",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "closed"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "opened"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
@@ -2059,31 +2059,31 @@
       "name": "cleverwatts",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "all"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -2097,25 +2097,25 @@
       "name": "clarus_switch",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -2129,31 +2129,31 @@
       "name": "beamish_switch",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "all"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -2167,25 +2167,25 @@
       "name": "auriol",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "battery"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "channel"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
@@ -2203,25 +2203,25 @@
       "name": "arctech_switch_old",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -2239,37 +2239,37 @@
       "name": "arctech_switch",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "learn"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "all"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
@@ -2283,25 +2283,25 @@
       "name": "arctech_screen_old",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "down"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "up"
@@ -2316,37 +2316,37 @@
       "name": "arctech_screen",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "learn"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "all"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "down"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "up"
@@ -2360,25 +2360,25 @@
       "name": "arctech_motion",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
@@ -2392,25 +2392,25 @@
       "name": "arctech_dusk",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "dawn"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "dusk"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
@@ -2424,43 +2424,43 @@
       "name": "arctech_dimmer",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "learn"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "all"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "off"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "on"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "dimlevel"
@@ -2475,31 +2475,31 @@
       "name": "arctech_contact",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "all"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "closed"
         },
         {
-          "data_type": [
+          "vartype": [
             "string"
           ],
           "name": "opened"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "unit"
@@ -2518,43 +2518,43 @@
       "name": "alecto_wx500",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "windgust"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "winddir"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "windavg"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "humidity"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "battery"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
@@ -2568,13 +2568,13 @@
       "name": "alecto_wsd17",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
@@ -2589,25 +2589,25 @@
       "name": "alecto_ws1700",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "battery"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "humidity"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "id"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "temperature"
@@ -2621,13 +2621,13 @@
       "name": "process",
       "options": [
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "ram"
         },
         {
-          "data_type": [
+          "vartype": [
             "number"
           ],
           "name": "cpu"

--- a/pilight/protocol_list.json
+++ b/pilight/protocol_list.json
@@ -1,0 +1,2638 @@
+{
+  "protocols": [
+    {
+      "devices": [
+        "ping"
+      ],
+      "name": "ping",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "ip"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "disconnected"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "connected"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "arping"
+      ],
+      "name": "arping",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "ip"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "mac"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "disconnected"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "connected"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "generic_webcam"
+      ],
+      "name": "generic_webcam",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "url"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "generic_weather"
+      ],
+      "name": "generic_weather",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "battery"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "humidity"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "generic_switch"
+      ],
+      "name": "generic_switch",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "generic_screen"
+      ],
+      "name": "generic_screen",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "down"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "up"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "generic_label"
+      ],
+      "name": "generic_label",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "color"
+        },
+        {
+          "data_type": [
+            "string",
+            "number"
+          ],
+          "name": "label"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "generic_dimmer"
+      ],
+      "name": "generic_dimmer",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "dimlevel"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "raw"
+      ],
+      "name": "raw",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "repeats"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "code"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "pilight_firmware"
+      ],
+      "name": "pilight_firmware",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "hpf"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "lpf"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "version"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "pilight_firmware"
+      ],
+      "name": "pilight_firmware",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "hpf"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "lpf"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "version"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "relay"
+      ],
+      "name": "relay",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "gpio"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "lm76"
+      ],
+      "name": "lm76",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "lm75"
+      ],
+      "name": "lm75",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "gpio_switch"
+      ],
+      "name": "gpio_switch",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "gpio"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "ds18s20"
+      ],
+      "name": "ds18s20",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "ds18b20"
+      ],
+      "name": "ds18b20",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "am2302",
+        "dht22"
+      ],
+      "name": "dht22",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "gpio"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "humidity"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "dht11"
+      ],
+      "name": "dht11",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "gpio"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "humidity"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "bmp085",
+        "bmp180"
+      ],
+      "name": "bmp180",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "pressure"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "oversampling"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "id"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "kodi",
+        "xbmc"
+      ],
+      "name": "xbmc",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "port"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "server"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "media"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "action"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "wunderground"
+      ],
+      "name": "wunderground",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "update"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "sun"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "sunset"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "sunrise"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "country"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "location"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "api"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "humidity"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "sunriseset"
+      ],
+      "name": "sunriseset",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "sun"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "sunset"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "sunrise"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "latitude"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "longitude"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "program"
+      ],
+      "name": "program",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "stopped"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "pending"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "running"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "arguments"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "pid"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "program"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "stop-command"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "start-command"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "name"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "openweathermap"
+      ],
+      "name": "openweathermap",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "update"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "sun"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "sunset"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "sunrise"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "country"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "location"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "humidity"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "lirc"
+      ],
+      "name": "lirc",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "remote"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "button"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "repeat"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "code"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "datetime"
+      ],
+      "name": "datetime",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "dst"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "second"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "minute"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "hour"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "weekday"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "day"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "month"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "year"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "latitude"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "longitude"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "cpu_temp"
+      ],
+      "name": "cpu_temp",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "x10"
+      ],
+      "name": "x10",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "tfa30"
+      ],
+      "name": "tfa30",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "humidity"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "GT-WT-01",
+        "NC7104",
+        "soens",
+        "conrad_weather",
+        "tfa"
+      ],
+      "name": "tfa",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "battery"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "humidity"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "channel"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "teknihall"
+      ],
+      "name": "teknihall",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "battery"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "humidity"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "techlico_switch"
+      ],
+      "name": "techlico_switch",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "tcm"
+      ],
+      "name": "tcm",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "battery"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "humidity"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "silvercrest"
+      ],
+      "name": "silvercrest",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unitcode"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "systemcode"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "selectremote"
+      ],
+      "name": "selectremote",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "secudo_smoke_sensor"
+      ],
+      "name": "secudo_smoke_sensor",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "alarm"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "sc2262"
+      ],
+      "name": "sc2262",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "closed"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "opened"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unitcode"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "systemcode"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "promax",
+        "rsl366"
+      ],
+      "name": "rsl366",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "programcode"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "systemcode"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "rev3_switch"
+      ],
+      "name": "rev3_switch",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "rev2_switch"
+      ],
+      "name": "rev2_switch",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "rev1_switch"
+      ],
+      "name": "rev1_switch",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "rc102",
+        "rc101"
+      ],
+      "name": "rc101",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "all"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "quigg_screen"
+      ],
+      "name": "quigg_screen",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "learn"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "all"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "down"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "up"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "quigg_gt9000"
+      ],
+      "name": "quigg_gt9000",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "quigg_gt7000"
+      ],
+      "name": "quigg_gt7000",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "learn"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "all"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "quigg_gt1000"
+      ],
+      "name": "quigg_gt1000",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "num"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "super"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "all"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "pollin"
+      ],
+      "name": "pollin",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unitcode"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "systemcode"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "ninjablocks_weather"
+      ],
+      "name": "ninjablocks_weather",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "humidity"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "mumbi"
+      ],
+      "name": "mumbi",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unitcode"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "systemcode"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "logilink_switch"
+      ],
+      "name": "logilink_switch",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unitcode"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "systemcode"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "impuls"
+      ],
+      "name": "impuls",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "programcode"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "systemcode"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "heitech"
+      ],
+      "name": "heitech",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unitcode"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "systemcode"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "ev1527"
+      ],
+      "name": "ev1527",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "closed"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "opened"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unitcode"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "eurodomest_switch"
+      ],
+      "name": "eurodomest_switch",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "learn"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "all"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "maxitronic",
+        "brennenstuhl",
+        "elro_800_switch"
+      ],
+      "name": "elro_800_switch",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unitcode"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "systemcode"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "elro_800_contact"
+      ],
+      "name": "elro_800_contact",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "closed"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "opened"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unitcode"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "systemcode"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "elro_400_switch"
+      ],
+      "name": "elro_400_switch",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unitcode"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "systemcode"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "elro_300_switch"
+      ],
+      "name": "elro_300_switch",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "all"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unitcode"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "systemcode"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "ehome"
+      ],
+      "name": "ehome",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "daycom"
+      ],
+      "name": "daycom",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "systemcode"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "conrad_rsl_switch"
+      ],
+      "name": "conrad_rsl_switch",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "learn"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "all"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "conrad_rsl_contact"
+      ],
+      "name": "conrad_rsl_contact",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "closed"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "opened"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "cleverwatts"
+      ],
+      "name": "cleverwatts",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "all"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "clarus_switch"
+      ],
+      "name": "clarus_switch",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "beamish_switch"
+      ],
+      "name": "beamish_switch",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "all"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "auriol"
+      ],
+      "name": "auriol",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "battery"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "channel"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "duwi",
+        "byebyestandby",
+        "intertechno_old",
+        "cogex",
+        "kaku_switch_old"
+      ],
+      "name": "arctech_switch_old",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "intertechno_switch",
+        "coco_switch",
+        "nexa_switch",
+        "dio_switch",
+        "kaku_switch"
+      ],
+      "name": "arctech_switch",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "learn"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "all"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "kaku_screen_old"
+      ],
+      "name": "arctech_screen_old",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "down"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "up"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "dio_screen",
+        "kaku_screen"
+      ],
+      "name": "arctech_screen",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "learn"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "all"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "down"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "up"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "kaku_motion"
+      ],
+      "name": "arctech_motion",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "kaku_dusk"
+      ],
+      "name": "arctech_dusk",
+      "options": [
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "dawn"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "dusk"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "kaku_dimmer"
+      ],
+      "name": "arctech_dimmer",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "learn"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "all"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "off"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "on"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "dimlevel"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "dio_contact",
+        "kaku_contact"
+      ],
+      "name": "arctech_contact",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "all"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "closed"
+        },
+        {
+          "data_type": [
+            "string"
+          ],
+          "name": "opened"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "unit"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "balance_rf_ws105",
+        "meteoscan_w1XX",
+        "hama_ews1500",
+        "ventus_wsxxx",
+        "auriol_h13726",
+        "alecto_wx500"
+      ],
+      "name": "alecto_wx500",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "windgust"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "winddir"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "windavg"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "humidity"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "battery"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "alecto_wsd17"
+      ],
+      "name": "alecto_wsd17",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "iboutique",
+        "alecto_ws1700"
+      ],
+      "name": "alecto_ws1700",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "battery"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "humidity"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "id"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "temperature"
+        }
+      ]
+    },
+    {
+      "devices": [
+        "process"
+      ],
+      "name": "process",
+      "options": [
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "ram"
+        },
+        {
+          "data_type": [
+            "number"
+          ],
+          "name": "cpu"
+        }
+      ]
+    }
+  ]
+}

--- a/pilight/protocol_schema.py
+++ b/pilight/protocol_schema.py
@@ -1,0 +1,98 @@
+import json
+import logging
+import voluptuous as vol
+
+from os import path
+
+
+KEY_PROTOCOLS = "protocols"
+KEY_DEVICES = "devices"
+KEY_NAME = "name"
+KEY_DATA_TYPE = "data_type"
+KEY_OPTIONS = "options"
+KEY_PROTOCOL = "protocol"
+
+
+logger = logging.getLogger(__name__)
+
+
+_types = {"string" : str,
+          "number": vol.Any(int, float)}
+
+
+def _default_schema():
+    """Load the fefault schema.
+
+    This is necessary until we have proper runtime protocol reporting support
+    in the pilight daemon.
+    """
+    with open(path.join(path.dirname(__file__), "protocol_list.json")) as fp:
+        return json.load(fp)
+
+
+def _convert_datatype(type_data):
+    if isinstance(type_data, (list, tuple)):
+        if len(type_data) == 1:
+            return _convert_datatype(type_data[0])
+        return vol.Any([_convert_datatype(t) for t in type_data])
+    
+    return _types.get(type_data)
+
+
+def _make_vol_schema(protocol_name, option_data):
+    option_schema = {vol.Required(KEY_PROTOCOL): protocol_name}
+    for option in option_data:
+        option_schema[vol.Optional(option.get(KEY_NAME))] =\
+                _convert_datatype(option.get(KEY_DATA_TYPE))
+
+    return vol.Schema(option_schema)
+
+
+class ProtocolSchema(object):
+    def __init__(self, schema_data):
+        self.name = schema_data.get(KEY_NAME)
+        self.devices = schema_data.get(KEY_DEVICES)
+        self.schema = _make_vol_schema(self.name, schema_data.get(KEY_OPTIONS))
+
+    def validate(self, data):
+        return self.schema(data)
+
+    def __repr__(self):
+        return "ProtocolSchema(name={}, schema={})".format(self.name,
+                                                           self.schema)
+
+
+class ProtocolRegistry(object):
+    def __init__(self, schema=None):
+        if schema is None:
+            logger.info("Use default protocol data")
+            schema = _default_schema()
+
+        self._protocols = {}
+
+        for protocol in schema.get("protocols"):
+            protocol_schema = ProtocolSchema(protocol)
+            self._protocols[protocol_schema.name] = protocol_schema
+            logger.debug("Added protocol '{}'".format(protocol_schema.name))
+
+    def validate(self, data, protocol_as_list=True):
+        protocol = data.get(KEY_PROTOCOL)
+
+        if protocol is None:
+            raise RuntimeError("No protocol specified in data!")
+
+        if isinstance(protocol, list):
+            protocol = protocol[0]
+
+        if protocol not in self._protocols:
+            raise RuntimeError("Unknown protocol '{}'".format(protocol))
+
+        protocol_schema = self._protocols[protocol]
+        validated = protocol_schema.schema(data)
+
+        if protocol_as_list:
+            validated[KEY_PROTOCOL] = [protocol]
+
+        return validated
+
+

--- a/pilight/protocol_schema.py
+++ b/pilight/protocol_schema.py
@@ -8,7 +8,7 @@ from os import path
 KEY_PROTOCOLS = "protocols"
 KEY_DEVICES = "devices"
 KEY_NAME = "name"
-KEY_DATA_TYPE = "data_type"
+KEY_DATA_TYPE = "vartype"
 KEY_OPTIONS = "options"
 KEY_PROTOCOL = "protocol"
 

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,  # Accept all data files and directories matched by MANIFEST.in or found in source control
     keywords=['pilight', '433', 'light'],
-    platforms='any'
+    platforms='any',
+    install_requires=["voluptuous"]
 )


### PR DESCRIPTION
This tries to add protocol schema verification (basically checking/conversion of datatypes) for the protocol data sent to the daemon. In the first version it uses a static protocol  schema dump generated from a patched pilight). The code to generate this is provided in [this PR](https://github.com/pilight/pilight/pull/322. 

As soon as this is merged we can detect the new feature from the pilight version and query it from the daemon itself.